### PR TITLE
Scope search query and popular events query for subdomains.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -396,4 +396,4 @@ DEPENDENCIES
   wkhtmltopdf-binary
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/app/controllers/bookings_controller.rb
+++ b/app/controllers/bookings_controller.rb
@@ -1,5 +1,6 @@
 class BookingsController < ApplicationController
-  before_action :authenticate_user, except: [:paypal_hook, :view_booking, :paypal_dummy]
+  before_action :authenticate_user,
+                except: [:paypal_hook, :view_booking, :paypal_dummy]
   before_action except: [:view_booking, :paypal_hook, :index, :paypal_dummy] do
     set_event
     ticket_params

--- a/app/controllers/bookings_controller.rb
+++ b/app/controllers/bookings_controller.rb
@@ -1,6 +1,6 @@
 class BookingsController < ApplicationController
-  before_action :authenticate_user, except: :paypal_hook
-  before_action except: [:view_booking, :paypal_hook, :index] do
+  before_action :authenticate_user, except: [:paypal_hook, :view_booking, :paypal_dummy]
+  before_action except: [:view_booking, :paypal_hook, :index, :paypal_dummy] do
     set_event
     ticket_params
     ticket_quantity_specified?
@@ -37,13 +37,8 @@ class BookingsController < ApplicationController
     render nothing: true
   end
 
-  def view_booking
-    if params[:item_number]
-      booking = Booking.find(params[:item_number])
-      redirect_to event_path(booking.event)
-    else
-      redirect_to events_path
-    end
+  def paypal_dummy
+    redirect_to tickets_path
   end
 
   private
@@ -60,9 +55,9 @@ class BookingsController < ApplicationController
     if @booking.amount == 0
       @booking.free!
       trigger_booking_mail
-      redirect_to @booking.event
+      redirect_to tickets_path
     else
-      redirect_to @booking.paypal_url(view_booking_path)
+      redirect_to @booking.paypal_url(paypal_dummy_path)
     end
   end
 

--- a/app/models/popular_query.rb
+++ b/app/models/popular_query.rb
@@ -8,10 +8,9 @@ class PopularQuery
   end
 
   def self.build
-    query = events.
-            project(Arel.star, bookings[:event_id].count.as("num")).
-            join(bookings).on(events[:id].eq(bookings[:event_id])).
-            group(events[:id]).order("num DESC")
-    query.to_sql
+    events.
+      project(Arel.star, bookings[:event_id].count.as("num")).
+      join(bookings).on(events[:id].eq(bookings[:event_id])).
+      group(events[:id]).order("num DESC")
   end
 end

--- a/app/models/search_query.rb
+++ b/app/models/search_query.rb
@@ -13,7 +13,7 @@ class SearchQuery
     append_by_match :location, event_location.downcase
     append_by_category category_id
     append_by_date_range EventDate.format(event_date)
-    @query.to_sql
+    @query
   end
 
   def append_by_match(column, word)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
   get "/my_events" => "users#show"
   get "events/loading"
   post "/paypal_hook" => "bookings#paypal_hook", as: :hook
-  post "/view" => "bookings#view_booking", as: :view_booking
+  post "/paypal_dummy" => "bookings#paypal_dummy", as: :paypal_dummy
   get "unattend", to: "attendees#destroy", as: "unattend"
   get "auth/:provider/callback", to: "sessions#create"
   get "auth/failure", to: redirect("/")


### PR DESCRIPTION
Modify PayPal return path to redirect to User ticket's page.

Why
Event searches (and related activities) within subdomains are expected
to return only information relating to the resources on the subdomain.
However due to the use of `raw sql` in retrieving the search and popular
events query, the subdomain scoping was being bypassed.
Also the return path for PayPal, hitherto redirects to event page and
this isn't very desirable.

This commit solves this by:
* Incorporating Act_as_tentant subdomain logic in the Arel query for search and popular events
* Creating a dummy unauthenticated action for PayPal return path and making it then redirect to the authenticated User tickets' page

Finishes [#108931598]
Finishes [#108931770]
Finishes [#108932162]