### PR TITLE
Comprehensive meta-tags

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ gem "wicked_pdf"
 gem "wkhtmltopdf-binary"
 gem "jwt"
 gem "httparty"
+gem "meta-tags"
 
 group :development, :test do
   gem "rspec-rails", "3.4.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,6 +151,8 @@ GEM
       mime-types (>= 1.16, < 3)
     materialize-sass (0.97.1)
       sass (~> 3.3)
+    meta-tags (2.1.0)
+      actionpack (>= 3.0.0)
     method_source (0.8.2)
     mime-types (2.6.2)
     mini_portile (0.6.2)
@@ -364,6 +366,7 @@ DEPENDENCIES
   jwt
   launchy (= 2.4.3)
   materialize-sass (= 0.97.1)
+  meta-tags
   nokogiri (= 1.6.6.2)
   omniauth-facebook (= 3.0.0)
   omniauth-github (= 1.1.2)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -13,18 +13,17 @@ class SessionsController < ApplicationController
   end
 
   def api_login
-    if params["token"].blank? || params["provider"].blank?
+    token = params[:token]
+    provider = params[:provider]
+    if token.blank? || ENV[provider].nil?
       render json: {}, status: 417
     else
-      token = params[:token]
-      @provider = params[:provider]
-      response = HTTParty.get(ENV[@provider],
-                              headers: { "Access_token"  => token,
-                                         "Authorization" => "OAuth #{token}" })
+      response = get_provider_uri(ENV[provider], token)
       userinfo = JSON.parse(response.body) if response.code == 200
-      @user = User.from_omniauth(create_auth_obj(userinfo)) if userinfo
-      api_key = @user.generate_auth_token if @user
+      api_user = get_api_user(userinfo, provider) if userinfo
+      api_key = api_user.generate_auth_token if api_user
       api_key ||= "Invalid token/provider supplied"
+      session[:user_id] = api_user.id if api_key
       render json: { api_key: api_key }
     end
   end
@@ -37,13 +36,23 @@ class SessionsController < ApplicationController
 
   private
 
-  def create_auth_obj(userinfo)
+  def get_api_user(userinfo, provider)
+    User.from_omniauth(create_auth_obj(userinfo, provider))
+  end
+
+  def get_provider_uri(provider, token)
+    HTTParty.get(provider, headers: { "Access_token"  => token,
+                                      "Authorization" => "OAuth #{token}" })
+  end
+
+  def create_auth_obj(userinfo, provider)
     auth = {}
-    auth["provider"] = @provider
+    auth["provider"] = provider
     auth["uid"] = userinfo["id"]
-    @pic = userinfo["picture"] if @provider == "google_oauth2"
-    @pic = userinfo["picture"]["url"] if @provider == "facebook"
-    auth["info"] = { image: @pic,
+    pic = nil
+    pic = userinfo["picture"] if provider == "google_oauth2"
+    pic = userinfo["picture"]["url"] if provider == "facebook"
+    auth["info"] = { image: pic,
                      email: userinfo["email"], name: userinfo["name"] }
     auth
   end

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,4 +1,5 @@
 class WelcomeController < ApplicationController
+  respond_to :html, :json
   def index
     @events = Event.upcoming_events
     respond_with @events

--- a/app/views/events/_eventdetails.html.erb
+++ b/app/views/events/_eventdetails.html.erb
@@ -28,9 +28,7 @@
           <%= render partial: "events/attend_unattend_event_button" %>
         </div>
         <%if @event.id%>
-          <%= social_share_button_tag(@event.title,
-          url: request.base_url + event_path(@event), image: @event.image,
-          desc: @event.description, popup: "true" ) %>
+            <%= social_share_button_tag(@event.title, popup: true)%>
         <%end%>
       </div>
       <div class="row center"></div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>EventX</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <%= stylesheet_link_tag "application",
   "https://fonts.googleapis.com/css?family=Great+Vibes",
@@ -13,6 +12,34 @@
   "data-turbolinks-track" => false %>
 
   <%= csrf_meta_tags %>
+    <% if @event && @event.id %>
+      <%
+      set_meta_tags title: @event.title,
+        type:  "event",
+        image: @event.image,
+        description: @event.description[0..150],
+        url: (request.base_url + event_path(@event))
+      %>
+      <%
+        set_meta_tags twitter: {
+          card: "summary",
+          title: @event.title,
+          image: @event.image,
+          description: @event.description[0..150],
+          url: (request.base_url + event_path(@event))
+        }
+      %>
+      <%
+        set_meta_tags og: {
+          title: @event.title,
+          type:  "event",
+          image: @event.image,
+          description: @event.description[0..150],
+          url: (request.base_url + event_path(@event))
+        }
+        %>
+    <% end %>
+    <%= display_meta_tags site: "EventX" %>
 </head>
 
 <body>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
   get "signout", to: "sessions#destroy", as: "signout"
   get "/session" => "sessions#create"
   post "/api_login" => "sessions#api_login"
+  post "/event_create" => "events#create"
   resources :manager_profiles
   resources :attendees
   resources :events do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -37,4 +37,6 @@ RSpec.configure do |config|
   end
   config.infer_spec_type_from_file_location!
   config.include ApplicationHelper
+  config.include Requests::JsonHelpers, type: :controller
+  config.include Requests::ApiHelper, type: :controller
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ SimpleCov.start "rails" do
     CodeClimate::TestReporter::Formatter
   ]
 end
+CodeClimate::TestReporter.start
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -1,0 +1,36 @@
+module Requests
+  module JsonHelpers
+    def json
+      JSON.parse(response.body)
+    end
+  end
+
+  module ApiHelper
+    def user_token
+      "CAAGE0WLOkNYBAPOHM5r8JOrJBut7zr6G46REZBfgbUnYQ7vCN4CrQimI60OH7\
+      gkIALgQTN5f6urenbL8IHb27NFKvk6n380ZCeYSyAp19ZCuYDQZBsrveZA96IJBm\
+      ZB9LTJ1vxBcgSalhVeZCsREvwnB8i08LjbBYLBWx44FSFvPLr1GyLQN9e2u9okfBuI67cZD"
+    end
+
+    def signin
+      params = { provider: "facebook", token: user_token }
+      post :api_login, params
+      @api_key = json["api_key"]
+    end
+
+    def api_key
+      @api_key
+    end
+
+    def create_api_event
+      event = FactoryGirl.attributes_for(:event)
+      request.headers["Authorization"] = "#{@api_key}"
+      post :create, event: event, format: "json"
+      @event = json["event"]
+    end
+
+    def event
+      @event
+    end
+  end
+end


### PR DESCRIPTION
WHY:
So that when an Event is shared on a social platform the Event immage and title is displayed

This is issue fixed by:
Making use of the meta-tags gem.
Writing set-meta-tags method to auto-generate header tags for each event.