### PR TITLE
Update Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,6 @@ group :development, :test do
   gem "rspec-rails", "3.4.0"
   gem "factory_girl_rails", "4.5.0"
   gem "sqlite3", "1.3.11"
-  gem "webmock"
   gem "pry-rails"
   gem "poltergeist"
   gem "database_cleaner", "1.5.1"
@@ -59,6 +58,8 @@ group :development, :test do
   gem "spring", "1.4.3"
   gem "coveralls", require: false
 end
+
+gem "webmock", :group => :test
 
 group :production do
   gem "pg", "0.17.1"


### PR DESCRIPTION
WHY:
To stop webmock from running in development environment.

This is fixed by:
Putting webmock gem in test environment.