### PR TITLE
Event managers should be able to add staffs while creating an event

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem "uglifier", ">= 1.3.0"
 gem "coffee-rails", "~> 4.1.0"
 gem "cancancan", "1.13.1"
 gem "jquery-rails", "4.0.5"
+gem "jquery-ui-rails", "5.0.5"
 gem "materialize-sass", "0.97.1"
 gem "font-awesome-sass", "4.4.0"
 gem "jbuilder", "~> 2.0"
@@ -15,7 +16,6 @@ gem "sdoc", "~> 0.4.0", group: :doc
 gem "redcarpet", "3.3.2"
 gem "nokogiri", "1.6.6.2"
 gem "draper", "2.1.0"
-gem "capybara", "2.5.0"
 gem "omniauth-oauth2", "~> 1.3.1"
 gem "omniauth-facebook", "3.0.0"
 gem "omniauth-google-oauth2", "0.2.10"
@@ -23,7 +23,6 @@ gem "omniauth-twitter", "1.2.1"
 gem "omniauth-linkedin", "0.2.0"
 gem "omniauth-github", "1.1.2"
 gem "omniauth-tumblr", "1.1"
-gem "rubocop", require: false
 gem "figaro", "1.1.1"
 gem "responders", "2.1.0"
 gem "launchy", "2.4.3"
@@ -34,7 +33,6 @@ gem "rmagick", "2.15.4"
 gem "cloudinary", "1.1.0"
 gem "delayed_job_active_record", "4.1.0"
 gem "daemons", "1.2.3"
-gem "faker", "1.5.0"
 gem "barby"
 gem "rqrcode"
 gem "wicked_pdf"
@@ -45,20 +43,26 @@ gem "meta-tags"
 gem "cocoon"
 
 group :development, :test do
-  gem "rspec-rails", "3.4.0"
-  gem "factory_girl_rails", "4.5.0"
   gem "sqlite3", "1.3.11"
   gem "pry-rails"
-  gem "poltergeist"
-  gem "database_cleaner", "1.5.1"
-  gem "simplecov", require: false
-  gem "codeclimate-test-reporter", require: nil
+  gem "pry-nav"
   gem "web-console", "~> 2.0"
   gem "spring", "1.4.3"
-  gem "coveralls", require: false
+  gem "rubocop", require: false
+  gem "faker", "1.5.0"
 end
 
-gem "webmock", group: :test
+group :test do
+  gem "capybara", "2.5.0"
+  gem "webmock", group: :test
+  gem "poltergeist"
+  gem "rspec-rails", "3.4.0"
+  gem "factory_girl_rails", "4.5.0"
+  gem "database_cleaner", "1.5.1"
+  gem "simplecov", require: false
+  gem "codeclimate-test-reporter", require: false
+  gem "coveralls", require: false
+end
 
 group :production do
   gem "pg", "0.17.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,6 +137,8 @@ GEM
       rails-dom-testing (~> 1.0)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    jquery-ui-rails (5.0.5)
+      railties (>= 3.2.16)
     json (1.8.3)
     jwt (1.5.2)
     launchy (2.4.3)
@@ -206,6 +208,8 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    pry-nav (0.2.4)
+      pry (>= 0.9.10, < 0.11.0)
     pry-rails (0.3.4)
       pry (>= 0.9.10)
     puma (2.11.1)
@@ -365,6 +369,7 @@ DEPENDENCIES
   httparty
   jbuilder (~> 2.0)
   jquery-rails (= 4.0.5)
+  jquery-ui-rails (= 5.0.5)
   jwt
   launchy (= 2.4.3)
   materialize-sass (= 0.97.1)
@@ -379,6 +384,7 @@ DEPENDENCIES
   omniauth-twitter (= 1.2.1)
   pg (= 0.17.1)
   poltergeist
+  pry-nav
   pry-rails
   puma (= 2.11.1)
   rails (= 4.2.1)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,6 +13,7 @@
 //= require jquery
 //= require cocoon
 //= require jquery_ujs
+//= require jquery-ui/autocomplete
 //= require materialize-sprockets
 //= require social-share-button
 //= require_tree .

--- a/app/assets/javascripts/event_staff.js
+++ b/app/assets/javascripts/event_staff.js
@@ -1,0 +1,18 @@
+$(document).ready(function(){
+  $(".add_staff_field").autocomplete({
+    delay: 500,
+    minLength: 4,
+    source: "/lookup_staffs",
+    select: function(event, ui){
+      var staffId = ui.item.data;
+      $.get("/user_info/" + staffId, function(data){
+        $(".event_staffs").append(data);
+        $(".add_staff_field").val("");
+      });
+    }
+  })
+
+  $(".event_staffs").on("click", ".remove_staff", function(){
+    $(this).parents(".chip").hide("slow");
+  })
+});

--- a/app/assets/javascripts/manager_profiles.coffee
+++ b/app/assets/javascripts/manager_profiles.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/events.scss
+++ b/app/assets/stylesheets/events.scss
@@ -274,3 +274,8 @@ input#event_photo_upload{
 .btn-large.home_button{
   margin-bottom: 20px;
 }
+
+.event_staffs{
+  margin-left: 8%;
+  margin-top: 3%;
+}

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -7,9 +7,8 @@ class EventsController < ApplicationController
   respond_to :html, :json, :js
 
   def new
-    @event = Event.new
+    @event = Event.new.decorate
     @event.ticket_types.build
-    @event.staffs.build
   end
 
   def index
@@ -30,8 +29,10 @@ class EventsController < ApplicationController
     respond_with @event
   end
 
-  def destroy_staff(id)
-    @event.event_staffs.find_by_id(id).destroy
+  def remove_staff
+    staff = EventStaff.find_by_id(params[:event_staff_id])
+    staff.destroy if staff
+    render nothing: true
   end
 
   def edit
@@ -48,11 +49,11 @@ class EventsController < ApplicationController
   end
 
   def create
-    @event = Event.new(event_params)
+    @event = Event.new(event_params).decorate
     @event.manager_profile = current_user.manager_profile
     @event.title = @event.title.strip
     if @event.save
-      @event.event_staffs.create(user: current_user).event_manager!
+      # @event.event_staffs.create(user: current_user).event_manager!
       flash[:notice] = "Your Event was successfully created."
     else
       flash[:notice] = @event.errors.full_messages.join("<br />")
@@ -73,8 +74,8 @@ class EventsController < ApplicationController
                                   :event_template_id,
                                   ticket_types_attributes:
                                     [:id, :_destroy, :name, :quantity, :price],
-                                  event_staffs:
-                                    [:role, :user_id, :id, :_destroy])
+                                  event_staffs_attributes:
+                                    [:user_id])
   end
 
   def set_events

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,8 +8,13 @@ class UsersController < ApplicationController
     respond_with @events
   end
 
-  def users_with_likely_emails(email)
-    User.with_alike_email(email).to_json
+  def lookup_staff_emails
+    render json: User.lookup_email(params[:entry])
+  end
+
+  def fetch_user_info
+    @user = User.first
+    render layout: false
   end
 
   def search_params

--- a/app/decorators/event_decorator.rb
+++ b/app/decorators/event_decorator.rb
@@ -7,7 +7,7 @@ class EventDecorator < Draper::Decorator
   end
 
   def start_date
-    object.start_date ? object.start_date.strftime("%b %d %Y") : ""
+    object.start_date ? object.start_date.strftime("%b %d %Y") : Time.zone.now
   end
 
   def event_template
@@ -15,6 +15,20 @@ class EventDecorator < Draper::Decorator
   end
 
   def end_date
-    object.end_date ? object.end_date.strftime("%b %d %Y") : ""
+    object.end_date ? object.end_date.strftime("%b %d %Y") : Time.zone.now
+  end
+
+  def get_event_staffs
+    event_staffs.inject("") do |all, staff|
+      role = "(#{staff.role})" if staff.role
+      user = staff.user
+      img = user.profile_url
+      name = "#{user.first_name} #{user.last_name}  #{role}"
+      all + "<div class='chip'>
+        <img src='#{img}' alt='Contact Person'>
+        #{name}&emsp;<a href='/remove_staff/#{staff.id}' data-remote='true'>
+        <span class='remove_staff'>x</span></a>
+      </div>"
+    end
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -6,7 +6,7 @@ class Event < ActiveRecord::Base
   has_many :staffs, through: :event_staffs, source: "user"
   accepts_nested_attributes_for :ticket_types,
                                 allow_destroy: true, reject_if: :all_blank
-  accepts_nested_attributes_for :staffs,
+  accepts_nested_attributes_for :event_staffs,
                                 allow_destroy: true,
                                 reject_if: :invalid_staff_info
 
@@ -72,6 +72,6 @@ class Event < ActiveRecord::Base
   private
 
   def invalid_staff_info(attr)
-    attr["role"].blank? || attr["user_id"].blank?
+    attr["user_id"].blank?
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,9 +19,10 @@ class User < ActiveRecord::Base
     end
   end
 
-  def self.with_alike_email(email)
-    query = users.where(users[:email].matches("%#{email}%")).limit(5).to_sql
-    find_by_sql(query)
+  def self.lookup_email(email)
+    where("email LIKE ? ", "%#{email}%").limit(5).map do |user|
+      { "value": user.email, "data": user.id }
+    end
   end
 
   def users

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -128,13 +128,9 @@
             <div class="event_ticket_field">
               <h5>Add Staff</h5>
               <hr>
-              <%= f.fields_for :staffs do |staff| %>
-              <%= render "staff_fields", :f => staff, :locals => {:f => staff} %>
-              <% end %>
+              <div class="event_staffs"><%= @event.get_event_staffs.html_safe %></div>
+              <%= render "staff_fields" %>
             </div>
-            <div class="links">
-            <%= link_to_add_association content_tag(:span, 'Add Staff', class: "btn btn-circle"), f, :staffs, :class => '' %>
-          </div>
         </div>
           </div>
         <!--End add staff -->

--- a/app/views/events/_staff_fields.html.erb
+++ b/app/views/events/_staff_fields.html.erb
@@ -1,9 +1,6 @@
-<div class="row col s12 nested-fields " id="paid_ticket_div" >
+<div class="row col s12" id="" >
   <div class="input-field col s5">
     <i class="fa fa-user prefix icon-setting"></i>
-    <%= f.text_field :email, placeholder: "Staff Email" %>
-  </div>
-  <div class="col s2 closecocoon">
-    <%= link_to_remove_association "x", f, class: "btn-floating btn waves-effect waves-light red"  %>
+    <input type="text" class= "add_staff_field" placeholder="Enter staff email"/>
   </div>
 </div>

--- a/app/views/manager_profiles/new.html.erb
+++ b/app/views/manager_profiles/new.html.erb
@@ -4,11 +4,11 @@
       <!-- START WRAPPER -->
       <div class="wrapper">
         <section id="content" >
-
   <%= form_for @manager_profile do |m| %>
   <div class="col s12">
       <div class="container">
         <div class="row">
+          <%= show_form_errors(@manager_profile) %>
       <div class="input-field col s10">
     <%= label_tag(:company_name, "Company Name") %>
     <%= m.text_field :company_name %>

--- a/app/views/users/fetch_user_info.html.erb
+++ b/app/views/users/fetch_user_info.html.erb
@@ -1,0 +1,5 @@
+<div class="chip">
+  <img src="<%= @user.profile_url %>" alt="Contact Person">
+  <%= "#{@user.first_name} #{@user.last_name}" %>&emsp;<a href="#" data-remote="true"><span class="remove_staff">x</span></a>
+  <input type="hidden" name = "event[event_staffs_attributes][][user_id]" value = "<%= @user.id %>" />
+</div>

--- a/app/views/welcome/upcoming_featured_latest.js.erb
+++ b/app/views/welcome/upcoming_featured_latest.js.erb
@@ -1,4 +1,0 @@
-events["<%= @type %>"] = "<%= j render template: 'events/events_card' %>"
-$("#events-card").html(events["<%= @type %>"]).fadeIn(1000);
-alert(events);
-alert(events["<%= @type %>"]);

--- a/circle.yml
+++ b/circle.yml
@@ -3,6 +3,7 @@ machine:
     version: 2.2.3
 test:
   override:
+    - bundle exec rake db:reset RAILS_ENV=test
     - bundle exec rake spec
 
 dependencies:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,9 @@ Rails.application.routes.draw do
   get "/upcoming_events" => "welcome#index"
   get "/my_events" => "users#show"
   get "events/loading"
+  get "/lookup_staffs" => "users#lookup_staff_emails"
+  get "/user_info/:id" => "users#fetch_user_info"
+  get "/remove_staff/:event_staff_id" => "events#remove_staff"
   post "/paypal_hook" => "bookings#paypal_hook", as: :hook
   post "/paypal_dummy" => "bookings#paypal_dummy", as: :paypal_dummy
   get "unattend", to: "attendees#destroy", as: "unattend"


### PR DESCRIPTION
Why?
Part of the information required for an event include the staffs for
the event. As such, being able to add this information while creating an
event _kind of_ unifies the process and should improve user experience.

This commit address this by:
* Adding accepted accept nested attributes feature to event to creation
* form
* Providing input field for managers to enter staff email when creating
* events
* Implementing Jquery autocomplete to enable managers add more than one
* staff at time
* Creating partial views for ajax query results for email autocomplete
* request

Finishes [#111956121]