### PR TITLE
Limit popular events and filter popular events by category

### DIFF
--- a/app/assets/stylesheets/application.css.scss.erb
+++ b/app/assets/stylesheets/application.css.scss.erb
@@ -377,3 +377,4 @@ margin-top: 70px
   color: #249c66;
   font-family: "europa", "Helvetica Neue", "Helvetica", Helvetica, Arial, sans-serif;
 }
+

--- a/app/assets/stylesheets/sponsor.scss
+++ b/app/assets/stylesheets/sponsor.scss
@@ -4,10 +4,6 @@
   }
 }
 
-.card-content a {
-  color: #2bbbad !important;
-}
-
 .event-sponsors-main {
   padding-left: 255px;
   padding-right: 20px;

--- a/app/assets/stylesheets/welcome.scss.erb
+++ b/app/assets/stylesheets/welcome.scss.erb
@@ -353,3 +353,8 @@ nav.custom_nav{
 .transform-text{
   text-transform: capitalize !important;
 }
+
+
+a.remove-text {
+  color: #ffffff !important;
+}

--- a/app/assets/stylesheets/welcome.scss.erb
+++ b/app/assets/stylesheets/welcome.scss.erb
@@ -340,3 +340,16 @@ nav.custom_nav{
   color: #fff;
   opacity: 0.90;
 }
+
+.remove-position{
+    color: #9e9e9e;
+    position: relative !important;
+    top: 0.02rem !important;
+    left: 0.75rem;
+    font-size: 1rem;
+    cursor: text;
+}
+
+.transform-text{
+  text-transform: capitalize !important;
+}

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -98,7 +98,21 @@ class EventsController < ApplicationController
   end
 
   def popular
-    @popular_events = Event.popular_events
+    if params[:category]
+      popular_events_by_category
+    else
+      @popular_events = Event.popular_events
+    end
+  end
+
+  def popular_events_by_category
+    events_category = Event.popular_events_category(params[:category]).empty?
+    if params[:category] && events_category
+      redirect_to events_popular_path,
+                  notice: "This category does not have a popular event"
+    else
+      @popular_events = Event.popular_by_categories(params[:category])
+    end
   end
 
   private

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -37,6 +37,9 @@ class Event < ActiveRecord::Base
     where(enabled: true).
       order(created_at: :DESC).limit(12)
   }
+  scope :popular_events_category, lambda { |category_id|
+    where(category_id: category_id)
+  }
   scope :featured_events, lambda {
     where(enabled: true).
       order(created_at: :DESC).limit(12)
@@ -109,6 +112,13 @@ class Event < ActiveRecord::Base
 
   def can_request_remit?
     Date.today >= (end_date + 5.days)
+  end
+
+  def self.popular_by_categories(id)
+    popular_events.select do |category|
+      category.
+        category_id == id.to_i
+    end
   end
 
   private

--- a/app/models/popular_query.rb
+++ b/app/models/popular_query.rb
@@ -11,6 +11,7 @@ class PopularQuery
     events.
       project(events[Arel.star], bookings[:event_id].count.as("num")).
       join(bookings).on(events[:id].eq(bookings[:event_id])).
-      where(events[:enabled].eq(true)).group(events[:id]).order("num DESC")
+      where(events[:enabled].eq(true)).group(events[:id]).
+      order("num DESC").take(9)
   end
 end

--- a/app/views/events/_filter_popular_categories.html.erb
+++ b/app/views/events/_filter_popular_categories.html.erb
@@ -1,0 +1,21 @@
+<% @categories = Category.list %>
+<div class="row">
+<%= form_tag(controller: "events", action: "popular" ) do %>
+<div class="input-field col s12 m6">
+<label class="remove-position">Filter Popular Event Categories</label>
+   <%= submit_tag "Filter Popular Event Categories", class: "waves-light btn" %>
+</div>
+
+<div class="input-field col s12 m6">
+<label class="remove-position">Select Categories</label>
+  <select name="category" class='browser-default' >
+      <option value="" disabled selected> Choose your option</option>
+    <% @categories.each_with_index do |category, index| %>
+    <option value="<%= category.id %>" id='dropdown-<%= "#{index}" %> '> <%= category.name %></option>
+    <%=link_to events_popular_path(category.id) %>
+      <% end %>
+  </select>
+</div>
+<% end %>
+</div>
+

--- a/app/views/events/_popular_events.html.erb
+++ b/app/views/events/_popular_events.html.erb
@@ -12,7 +12,7 @@
             <span class="card-title grey-text text-darken-4">
               <%= event.start_date.strftime("%b %d %Y") %>
             </span>
-          <p><%=link_to event.title, event %></p>
+          <p><%=link_to event.title, event, class: "remove-text" %></p>
         </div>
 
         <div class="card-action">

--- a/app/views/events/popular.html.erb
+++ b/app/views/events/popular.html.erb
@@ -8,6 +8,7 @@
     <%= render partial: "layouts/dashboard_sidebar"%>
     <div class= "row">
     <%= render partial: "popular_events_slides"%>
+    <%= render partial: "filter_popular_categories"%>
     <%= render partial: "popular_events"%>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,6 @@ Rails.application.routes.draw do
   get "/featured_events" => "welcome#featured"
   get "/popular_events" => "welcome#popular"
   match "/events/popular" => "events#popular", via: [:post, :get]
-  post "/events/popular_categories" => "events#popular_categories"
   get "/upcoming_events" => "welcome#index"
   get "/my_events" => "users#show"
   get "events/loading"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,8 @@ Rails.application.routes.draw do
   get "/events/:id/generate" => "events#generate", as: :generate_event
   get "/featured_events" => "welcome#featured"
   get "/popular_events" => "welcome#popular"
-  get "/events/popular" => "events#popular"
+  match "/events/popular" => "events#popular", via: [:post, :get]
+  post "/events/popular_categories" => "events#popular_categories"
   get "/upcoming_events" => "welcome#index"
   get "/my_events" => "users#show"
   get "events/loading"

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe EventsController, type: :controller do
   end
 
   describe "#popular" do
-    context "when an event manager or user has popular events" do
+    context "when popular events exist" do
       it "renders the popular events" do
         get :popular
 
@@ -34,6 +34,30 @@ RSpec.describe EventsController, type: :controller do
         expect(assigns[:events][0].manager_profile_id).to eq 1
         expect(assigns[:events].count).to eq 1
         expect(response).to render_template "events/popular"
+      end
+    end
+  end
+
+  describe "#popular" do
+    context "when popular events categories filtered exist" do
+      it "renders the popular events of the category filtered" do
+        get :popular, category: 1
+
+        expect(assigns[:events][0].category_id).to eq 1
+        expect(assigns[:events][0].category.name).to eq "Music"
+        expect(response).to render_template "events/popular"
+      end
+    end
+  end
+
+  describe "#popular" do
+    context "when popular events categories filtered does not exist" do
+      it "renders an error message" do
+        get :popular, category: 3
+
+        expect(
+          flash[:notice]
+        ).to eq "This category does not have a popular event"
       end
     end
   end

--- a/spec/features/tickets_report_spec.rb
+++ b/spec/features/tickets_report_spec.rb
@@ -30,23 +30,23 @@ RSpec.feature "TicketsReport", type: :feature, js: true do
     visit tickets_report_path(@event.id)
     expect(page.current_path).to eq tickets_report_path(@event.id)
     page_should_have_content([
-                              "Tickets",
-                              "Grand Total",
-                              "All Bookings",
-                              "ALL BOOKINGS",
-                              "ATTENDEES"
-                            ])
+      "Tickets",
+      "Grand Total",
+      "All Bookings",
+      "ALL BOOKINGS",
+      "ATTENDEES"
+    ])
 
     within '#tickets_summary_table thead' do
       page_should_have_content([
-                                "S/N",
-                                "Name",
-                                "Quantity",
-                                "Quantity Sold",
-                                "Ticket Left",
-                                "Price",
-                                "Amount"
-                              ])
+        "S/N",
+        "Name",
+        "Quantity",
+        "Quantity Sold",
+        "Ticket Left",
+        "Price",
+        "Amount"
+      ])
     end
   end
 end

--- a/spec/features/tickets_report_spec.rb
+++ b/spec/features/tickets_report_spec.rb
@@ -30,23 +30,23 @@ RSpec.feature "TicketsReport", type: :feature, js: true do
     visit tickets_report_path(@event.id)
     expect(page.current_path).to eq tickets_report_path(@event.id)
     page_should_have_content([
-      "Tickets",
-      "Grand Total",
-      "All Bookings",
-      "ALL BOOKINGS",
-      "ATTENDEES"
-    ])
+                              "Tickets",
+                              "Grand Total",
+                              "All Bookings",
+                              "ALL BOOKINGS",
+                              "ATTENDEES"
+                            ])
 
     within '#tickets_summary_table thead' do
       page_should_have_content([
-        "S/N",
-        "Name",
-        "Quantity",
-        "Quantity Sold",
-        "Ticket Left",
-        "Price",
-        "Amount"
-      ])
+                                "S/N",
+                                "Name",
+                                "Quantity",
+                                "Quantity Sold",
+                                "Ticket Left",
+                                "Price",
+                                "Amount"
+                              ])
     end
   end
 end


### PR DESCRIPTION
#### What does this PR do?
Displays Popular Events with a limited no of nine(9) and also gives the Event Manger or User the opportunity to filter popular events by their event category. 

#### How should this be manually tested?
Log in to eventx web app. Become an Event Manager by creating an event which has more than one booking, click on Popular Events on the side bar to view Popular Events. Popular Events are displayed based on the number of attendees or booking that an event has. 

#### What are the relevant pivotal tracker stories?
103821188

#### Screenshots (if appropriate)
![image](https://cloud.githubusercontent.com/assets/14160244/15513786/0e4db64c-21de-11e6-893b-d04536f66de6.png)
